### PR TITLE
Reduce load times

### DIFF
--- a/meta_capstone/ActiveGameCell.h
+++ b/meta_capstone/ActiveGameCell.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setCellInfo:(PFObject *)game;
 
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/meta_capstone/ActiveGameCell.m
+++ b/meta_capstone/ActiveGameCell.m
@@ -26,11 +26,22 @@
     self.game = game;
     PFQuery *query = [PFQuery queryWithClassName:@"AppUser"];
     [query whereKey:@"fbID" equalTo:game[@"hostID"]];
-    self.hostUserLabel.text = [NSString stringWithFormat:@"Host: %@", [query findObjects].firstObject[@"name"]];
+    PFObject *host = [query findObjects].firstObject;
+    self.hostUserLabel.text = [NSString stringWithFormat:@"Host: %@", host[@"name"]];
     
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     dateFormatter.dateFormat = @"HH:mm 'on' MM/dd";
     self.boardFillLabel.text = [NSString stringWithFormat:@"Game started at %@", [dateFormatter stringFromDate:game.createdAt]];
+    
+    //get profile picture
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+    initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", host[@"fbID"]]
+        parameters:nil
+        HTTPMethod:@"GET"];
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
+        self.hostProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+    }];
 }
 
 @end

--- a/meta_capstone/Base.lproj/Main.storyboard
+++ b/meta_capstone/Base.lproj/Main.storyboard
@@ -317,17 +317,16 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Board is 00% filled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kJb-Zx-Rb9">
-                                                    <rect key="frame" x="92" y="59" width="302" height="17"/>
+                                                    <rect key="frame" x="92" y="59" width="121.5" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="kJb-Zx-Rb9" firstAttribute="leading" secondItem="Zk9-yn-xvH" secondAttribute="trailing" constant="8" symbolic="YES" id="2ie-Q1-0og"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="kJb-Zx-Rb9" secondAttribute="trailing" id="3Pn-Ra-gDS"/>
+                                                <constraint firstItem="kJb-Zx-Rb9" firstAttribute="leading" secondItem="BMw-Hd-81S" secondAttribute="leading" id="0zv-Cx-9Vh"/>
+                                                <constraint firstItem="kJb-Zx-Rb9" firstAttribute="top" secondItem="BMw-Hd-81S" secondAttribute="bottom" constant="3" id="8G7-QZ-QNW"/>
                                                 <constraint firstItem="Zk9-yn-xvH" firstAttribute="top" secondItem="La3-XD-Mem" secondAttribute="topMargin" id="Eq6-oT-cOo"/>
-                                                <constraint firstItem="kJb-Zx-Rb9" firstAttribute="baseline" secondItem="Zk9-yn-xvH" secondAttribute="firstBaseline" id="J1h-uV-aK8"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="Zk9-yn-xvH" secondAttribute="bottom" id="JiO-29-taz"/>
                                                 <constraint firstItem="BMw-Hd-81S" firstAttribute="leading" secondItem="Zk9-yn-xvH" secondAttribute="trailing" constant="8" symbolic="YES" id="WeT-nJ-DSG"/>
                                                 <constraint firstItem="Zk9-yn-xvH" firstAttribute="leading" secondItem="La3-XD-Mem" secondAttribute="leadingMargin" id="ZTN-fa-HM0"/>

--- a/meta_capstone/ViewControllers/InGameViewController.m
+++ b/meta_capstone/ViewControllers/InGameViewController.m
@@ -38,6 +38,8 @@
     //initialize timer
     self.timer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
     [self.timer fire];
+    
+    self.emptyTile = [[[PFQuery queryWithClassName:@"Tile"] whereKey:@"fillable" equalTo:@NO] findObjects].firstObject; //init emptyTile object
         
     //if no board already in database, create empty board
     if (self.game[@"tilesArray"] == nil) {
@@ -93,7 +95,6 @@
         self.yIndex = 0;
         
         //initialize tilesArray with all unfillable tiles
-        self.emptyTile = [[[PFQuery queryWithClassName:@"Tile"] whereKey:@"fillable" equalTo:@NO] findObjects].firstObject; //init emptyTile object
         int size = 10; //to make square grid
         
         //fill inner array
@@ -117,6 +118,7 @@
         NSArray *words = [self.wordCluePairs allKeys];
         [self createBoard:words];
     }
+    [self refreshTilesArray];
     
     //if user is not the host, remove check button
     if ([self.game[@"hostID"] isEqualToString:self.currUser[@"fbID"]]) {
@@ -148,6 +150,7 @@
     self.game = [[PFQuery queryWithClassName:@"Game"] getObjectWithId:self.game.objectId];
     if ([self.game[@"updated"] boolValue]) {
         self.game[@"updated"] = @NO;
+        [self refreshTilesArray];
         [self.boardCollectionView reloadData];
     }
 }
@@ -258,10 +261,35 @@
     }
 }
 
+//query all tiles in game, set to tilesArray
+- (void) refreshTilesArray {
+    self.game = [[PFQuery queryWithClassName:@"Game"] getObjectWithId:self.game.objectId];
+    NSArray *availableTilesInGame = [[[PFQuery queryWithClassName:@"Tile"] whereKey:@"gameID" equalTo:self.game.objectId] findObjects];
+    NSMutableArray *tilesArray = [NSMutableArray arrayWithArray:@[]];
+    
+    NSArray *tileIDsArray = self.game[@"tilesArray"];
+    for (NSArray *tileIDsRow in tileIDsArray) {
+        NSMutableArray *tilesRow = [NSMutableArray arrayWithArray:@[]];
+        for (NSString *tileID in tileIDsRow) {
+            [tilesRow addObject:[self findTileInArrayWithID:availableTilesInGame :tileID]];
+        }
+        [tilesArray addObject:[NSArray arrayWithArray:tilesRow]];
+    }
+    self.tilesArray = tilesArray;
+}
+
+- (PFObject *) findTileInArrayWithID : (NSArray *)tiles : (NSString *)tileID {
+    for (PFObject* tile in tiles) {
+        if ([tile.objectId isEqualToString:tileID])
+            return tile;
+    }
+    return self.emptyTile;
+}
+
+//query individual tile
 - (PFObject *) getTileAtIndex : (int) xIndex : (int) yIndex {
-    NSMutableArray *innerArray = [self.game[@"tilesArray"] objectAtIndex:yIndex];
-    NSString *tileID = [innerArray objectAtIndex:xIndex];
-    return [[PFQuery queryWithClassName:@"Tile"] getObjectWithId:tileID];
+    NSMutableArray *innerArray = [self.tilesArray objectAtIndex:yIndex];
+    return [innerArray objectAtIndex:xIndex];
 }
 
 - (void) setTileAtIndex : (PFObject *) tile : (int) xIndex : (int) yIndex {
@@ -271,6 +299,7 @@
     [tilesArray replaceObjectAtIndex:yIndex withObject:innerArray];
     self.game[@"tilesArray"] = tilesArray;
     [self.game save];
+    [self refreshTilesArray];
 }
 
 //initialize board ui

--- a/meta_capstone/ViewControllers/LeaderboardViewController.m
+++ b/meta_capstone/ViewControllers/LeaderboardViewController.m
@@ -18,6 +18,7 @@
 @implementation LeaderboardViewController
 
 - (void)viewDidAppear:(BOOL)animated {
+    [self getLeaderboard];
     [self.tableView reloadData];
 }
 

--- a/meta_capstone/ViewControllers/SelfProfileViewController.m
+++ b/meta_capstone/ViewControllers/SelfProfileViewController.m
@@ -77,7 +77,6 @@
 
     NSArray *users = [query findObjects];
     self.recentsArray = [NSMutableArray arrayWithArray:users];
-
 }
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {


### PR DESCRIPTION
## Description
- Added a local tile store, so once the board is instantiated, less queries have to be done to the server in order to open, update, or check a board
- Reduces querying by querying once for all tiles on a refresh instead of doing an individual query for each tile in the 10x10 grid
- Time to open/check reduced from around 10-15s to about 2s


## Milestones
Feature: Improving game board (updates, load-in, checking is faster and fewer queries)

## Test Plan

first instantiation still takes a while

https://user-images.githubusercontent.com/22784306/182983615-1ddbbec2-e903-45f5-b682-239827f7b3e2.mov


https://user-images.githubusercontent.com/22784306/182983634-23dd665d-ad9f-4d29-b108-2368adc60873.mov


