### PR TITLE
Improve visual

### DIFF
--- a/meta_capstone.xcodeproj/project.pbxproj
+++ b/meta_capstone.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7ED07A82288F1C3500DF6DB5 /* BoardTileCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED07A81288F1C3500DF6DB5 /* BoardTileCell.m */; };
 		7ED16BBD2887567200E999A4 /* InGameViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED16BBC2887567200E999A4 /* InGameViewController.m */; };
 		7ED28F8028A319C8007CC821 /* UIViewController+TileMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED28F7F28A319C8007CC821 /* UIViewController+TileMethods.m */; };
+		7ED28F8328A5C303007CC821 /* TableViewCell+ProfileMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ED28F8228A5C303007CC821 /* TableViewCell+ProfileMethods.m */; };
 		807BDA1571383951FC66A50C /* Pods_meta_capstoneTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 392B41199053CF98C3CA7144 /* Pods_meta_capstoneTests.framework */; };
 		8D69A46299E92FF3E94639A9 /* Pods_meta_capstone.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C8C0553A4D2C202E659169C /* Pods_meta_capstone.framework */; };
 /* End PBXBuildFile section */
@@ -119,6 +120,8 @@
 		7ED16BBC2887567200E999A4 /* InGameViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InGameViewController.m; sourceTree = "<group>"; };
 		7ED28F7E28A319C8007CC821 /* UIViewController+TileMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "UIViewController+TileMethods.h"; path = "ViewControllers/UIViewController+TileMethods.h"; sourceTree = "<group>"; };
 		7ED28F7F28A319C8007CC821 /* UIViewController+TileMethods.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+TileMethods.m"; path = "ViewControllers/UIViewController+TileMethods.m"; sourceTree = "<group>"; };
+		7ED28F8128A5C303007CC821 /* TableViewCell+ProfileMethods.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TableViewCell+ProfileMethods.h"; sourceTree = "<group>"; };
+		7ED28F8228A5C303007CC821 /* TableViewCell+ProfileMethods.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TableViewCell+ProfileMethods.m"; sourceTree = "<group>"; };
 		8C8C0553A4D2C202E659169C /* Pods_meta_capstone.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_meta_capstone.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C42136471466BBEC7967B215 /* Pods-meta_capstoneTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-meta_capstoneTests.debug.xcconfig"; path = "Target Support Files/Pods-meta_capstoneTests/Pods-meta_capstoneTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -209,6 +212,8 @@
 				7E07F3D32874B95D008DFE55 /* LaunchScreen.storyboard */,
 				7E07F3D62874B95D008DFE55 /* Info.plist */,
 				7E07F3D72874B95D008DFE55 /* main.m */,
+				7ED28F8128A5C303007CC821 /* TableViewCell+ProfileMethods.h */,
+				7ED28F8228A5C303007CC821 /* TableViewCell+ProfileMethods.m */,
 				7ED28F7E28A319C8007CC821 /* UIViewController+TileMethods.h */,
 				7ED28F7F28A319C8007CC821 /* UIViewController+TileMethods.m */,
 				7ED07A80288F1C3500DF6DB5 /* BoardTileCell.h */,
@@ -527,6 +532,7 @@
 				7E901B2D2881E2AC00C34BEA /* NewGameViewController.m in Sources */,
 				7E901B27287F5FBD00C34BEA /* ActiveGameCell.m in Sources */,
 				7E2996232874D6EB00940B99 /* LeaderboardViewController.m in Sources */,
+				7ED28F8328A5C303007CC821 /* TableViewCell+ProfileMethods.m in Sources */,
 				7E901B302882239D00C34BEA /* SearchUserCell.m in Sources */,
 				7E29961D2874BF0D00940B99 /* LoginViewController.m in Sources */,
 				7E901B24287E37C500C34BEA /* SimpleProfileCell.m in Sources */,

--- a/meta_capstone/ActiveGameCell.h
+++ b/meta_capstone/ActiveGameCell.h
@@ -7,10 +7,11 @@
 
 #import <UIKit/UIKit.h>
 #import "Parse/Parse.h"
+#import "TableViewCell+ProfileMethods.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ActiveGameCell : UITableViewCell
+@interface ActiveGameCell : TableViewCell_ProfileMethods
 
 @property (strong, nonatomic) IBOutlet UIImageView *hostProfileImage;
 @property (strong, nonatomic) IBOutlet UILabel *hostUserLabel;

--- a/meta_capstone/ActiveGameCell.m
+++ b/meta_capstone/ActiveGameCell.m
@@ -33,10 +33,7 @@
     dateFormatter.dateFormat = @"HH:mm 'on' MM/dd";
     self.boardFillLabel.text = [NSString stringWithFormat:@"Game started at %@", [dateFormatter stringFromDate:game.createdAt]];
     
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", host[@"fbID"]]];
-    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
-    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
-    self.hostProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.hostProfileImage.image = [self getProfilePictureForUser:host[@"fbID"]];
     self.hostProfileImage.layer.cornerRadius = self.hostProfileImage.frame.size.width / 2;
 }
 

--- a/meta_capstone/ActiveGameCell.m
+++ b/meta_capstone/ActiveGameCell.m
@@ -41,6 +41,8 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
         self.hostProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+        self.hostProfileImage.layer.cornerRadius = self.hostProfileImage.frame.size.width / 2;
+
     }];
 }
 

--- a/meta_capstone/ActiveGameCell.m
+++ b/meta_capstone/ActiveGameCell.m
@@ -33,17 +33,11 @@
     dateFormatter.dateFormat = @"HH:mm 'on' MM/dd";
     self.boardFillLabel.text = [NSString stringWithFormat:@"Game started at %@", [dateFormatter stringFromDate:game.createdAt]];
     
-    //get profile picture
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-    initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", host[@"fbID"]]
-        parameters:nil
-        HTTPMethod:@"GET"];
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
-        self.hostProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
-        self.hostProfileImage.layer.cornerRadius = self.hostProfileImage.frame.size.width / 2;
-
-    }];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", host[@"fbID"]]];
+    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+    self.hostProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.hostProfileImage.layer.cornerRadius = self.hostProfileImage.frame.size.width / 2;
 }
 
 @end

--- a/meta_capstone/Base.lproj/Main.storyboard
+++ b/meta_capstone/Base.lproj/Main.storyboard
@@ -221,8 +221,8 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recently Played:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Xq-Fd-86g">
-                                <rect key="frame" x="20" y="224" width="232" height="36"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recently Played With:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Xq-Fd-86g">
+                                <rect key="frame" x="20" y="224" width="304.5" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -396,15 +396,16 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2zw-iV-LLa">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2zw-iV-LLa">
                                 <rect key="frame" x="20" y="732" width="374" height="80"/>
-                                <color key="backgroundColor" name="CTBlue"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="80" id="NHC-lz-X9N"/>
                                 </constraints>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="New Game">
+                                    <backgroundConfiguration key="background">
+                                        <color key="backgroundColor" name="CTBlue"/>
+                                    </backgroundConfiguration>
                                     <fontDescription key="titleFontDescription" type="system" weight="medium" pointSize="32"/>
                                 </buttonConfiguration>
                                 <connections>
@@ -442,7 +443,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="XJV-la-oin">
-                                <rect key="frame" x="0.0" y="88" width="414" height="665.5"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="652"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <searchBar key="tableHeaderView" contentMode="redraw" id="VVe-Yp-te0">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -505,13 +506,15 @@
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gdu-WZ-Hq0">
                                 <rect key="frame" x="20" y="748" width="374" height="80"/>
-                                <color key="backgroundColor" name="CTBlue"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="80" id="0QG-wl-Edn"/>
                                 </constraints>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Start Game">
+                                    <backgroundConfiguration key="background">
+                                        <color key="backgroundColor" name="CTBlue"/>
+                                    </backgroundConfiguration>
                                     <fontDescription key="titleFontDescription" type="system" weight="medium" pointSize="32"/>
                                 </buttonConfiguration>
                                 <connections>
@@ -526,7 +529,7 @@
                             <constraint firstItem="XJV-la-oin" firstAttribute="leading" secondItem="sth-Zb-FDi" secondAttribute="leading" id="AaH-69-nWt"/>
                             <constraint firstItem="gdu-WZ-Hq0" firstAttribute="leading" secondItem="sth-Zb-FDi" secondAttribute="leading" constant="20" id="CJS-qf-Lcm"/>
                             <constraint firstItem="XJV-la-oin" firstAttribute="top" secondItem="sth-Zb-FDi" secondAttribute="top" id="SMZ-zd-Fig"/>
-                            <constraint firstItem="gdu-WZ-Hq0" firstAttribute="firstBaseline" secondItem="XJV-la-oin" secondAttribute="baseline" constant="45.5" symbolType="layoutAnchor" id="Y9Z-bH-JZe"/>
+                            <constraint firstItem="gdu-WZ-Hq0" firstAttribute="top" secondItem="XJV-la-oin" secondAttribute="bottom" constant="8" symbolic="YES" id="cAi-ZC-0RC"/>
                             <constraint firstItem="sth-Zb-FDi" firstAttribute="bottom" secondItem="gdu-WZ-Hq0" secondAttribute="bottom" constant="34" id="hdW-Fj-GIV"/>
                             <constraint firstItem="XJV-la-oin" firstAttribute="trailing" secondItem="sth-Zb-FDi" secondAttribute="trailing" id="xQ9-MJ-gSY"/>
                         </constraints>
@@ -547,7 +550,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="skR-d0-JQk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4632" y="-858"/>
+            <point key="canvasLocation" x="4631.884057971015" y="-858.48214285714278"/>
         </scene>
         <!--Board-->
         <scene sceneID="jot-Ib-OPk">
@@ -590,7 +593,7 @@
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Clues" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4AX-u7-GsN">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4AX-u7-GsN">
                                 <rect key="frame" x="20" y="448" width="374" height="26.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="urm-tE-5Bd"/>
@@ -657,7 +660,6 @@
                         <segue destination="9xO-Ph-p3q" kind="relationship" relationship="viewControllers" id="Iwz-Ti-sR3"/>
                         <segue destination="Lmv-j7-ZDP" kind="relationship" relationship="viewControllers" id="qrW-Bb-NKe"/>
                         <segue destination="CFZ-yl-Epr" kind="relationship" relationship="viewControllers" id="MvE-lv-bby"/>
-                        <segue destination="Mcz-OX-coB" kind="relationship" relationship="viewControllers" id="4Jq-JI-oDk"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3ah-fe-BPe" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/meta_capstone/Base.lproj/Main.storyboard
+++ b/meta_capstone/Base.lproj/Main.storyboard
@@ -169,7 +169,7 @@
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.2.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="MaN-Wv-xsn">
                                 <rect key="frame" x="20" y="250" width="50" height="47"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" name="CTOrange"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="IBI-A9-mo7"/>
                                     <constraint firstAttribute="width" constant="50" id="OlI-6V-88T"/>
@@ -232,7 +232,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recently Played With" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Xq-Fd-86g">
                                 <rect key="frame" x="78" y="256" width="287" height="35"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="29"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" name="CTOrange"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -299,7 +299,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active Games" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gZc-gW-J1M">
                                 <rect key="frame" x="73" y="88" width="194" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" name="CTOrange"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="gameTable" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="eSt-oD-6P4">
@@ -359,7 +359,7 @@
                                 <rect key="frame" x="73" y="410" width="215" height="36"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" name="CTOrange"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" restorationIdentifier="inviteTable" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="z8L-ml-34K">
@@ -427,12 +427,12 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="envelope" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bmZ-yz-YqY">
                                 <rect key="frame" x="20" y="412" width="45" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" name="CTOrange"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="square.grid.3x2" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BYA-bd-1dA">
                                 <rect key="frame" x="20" y="92" width="45" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" name="CTOrange"/>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Xsf-DX-OVI"/>
@@ -603,7 +603,7 @@
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" text="W" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JPb-aB-2ce">
                                                     <rect key="frame" x="-7" y="-6" width="45" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <color key="textColor" systemColor="labelColor"/>
+                                                    <color key="textColor" name="CTBlue"/>
                                                     <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="23"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" spellCheckingType="no"/>
                                                 </textView>
@@ -698,7 +698,7 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="CTOrange"/>
+                            <color key="textColor" systemColor="labelColor"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -720,7 +720,7 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="CTOrange"/>
+                            <color key="textColor" systemColor="labelColor"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -743,7 +743,7 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="CTOrange"/>
+                            <color key="textColor" systemColor="labelColor"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -800,7 +800,7 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="CTOrange"/>
+                            <color key="textColor" systemColor="labelColor"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -821,7 +821,7 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="CTOrange"/>
+                            <color key="textColor" systemColor="labelColor"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/meta_capstone/Base.lproj/Main.storyboard
+++ b/meta_capstone/Base.lproj/Main.storyboard
@@ -84,7 +84,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JEX-gB-izl">
                                                     <rect key="frame" x="20" y="20" width="72" height="43"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" name="CTOrange"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="S9X-Ok-nyO">
@@ -98,7 +98,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Avg Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bUW-qa-MIA">
                                                     <rect key="frame" x="170" y="63.5" width="224" height="19.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" name="CTBlue"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hsc-nG-OWx">
@@ -162,25 +162,33 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Avg Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EKL-Ff-i5b">
-                                <rect key="frame" x="156" y="192" width="238" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="156" y="166.5" width="238" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <color key="textColor" name="CTBlue"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Best Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XDK-En-yrH">
-                                <rect key="frame" x="156" y="168" width="238" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.2.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="MaN-Wv-xsn">
+                                <rect key="frame" x="20" y="250" width="50" height="47"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="IBI-A9-mo7"/>
+                                    <constraint firstAttribute="width" constant="50" id="OlI-6V-88T"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" misplaced="YES" text="Best Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XDK-En-yrH">
+                                <rect key="frame" x="156" y="137" width="238" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <color key="textColor" name="CTBlue"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Total Games" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-Ob-hFa">
-                                <rect key="frame" x="156" y="144" width="238" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="156" y="108.5" width="238" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <color key="textColor" name="CTBlue"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="FJq-Rm-ds6">
-                                <rect key="frame" x="0.0" y="268" width="414" height="628"/>
+                                <rect key="frame" x="0.0" y="300" width="414" height="596"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="recentCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="recentCell" rowHeight="83" id="qt3-9f-qXE" customClass="SimpleProfileCell">
@@ -221,9 +229,9 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recently Played With:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Xq-Fd-86g">
-                                <rect key="frame" x="20" y="224" width="304.5" height="36"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recently Played With" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Xq-Fd-86g">
+                                <rect key="frame" x="78" y="256" width="287" height="35"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="29"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -231,23 +239,26 @@
                         <viewLayoutGuide key="safeArea" id="Tvb-2K-ZWp"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="EKL-Ff-i5b" firstAttribute="top" secondItem="XDK-En-yrH" secondAttribute="bottom" id="1Ee-V8-Yzc"/>
                             <constraint firstItem="fIm-Ob-hFa" firstAttribute="leading" secondItem="XDK-En-yrH" secondAttribute="leading" id="ADz-2u-Own"/>
                             <constraint firstItem="fIm-Ob-hFa" firstAttribute="trailing" secondItem="XDK-En-yrH" secondAttribute="trailing" id="Bce-ww-UWc"/>
+                            <constraint firstItem="XDK-En-yrH" firstAttribute="centerY" secondItem="5fo-ec-5oo" secondAttribute="centerY" id="DTX-33-i1V"/>
+                            <constraint firstItem="MaN-Wv-xsn" firstAttribute="top" secondItem="5fo-ec-5oo" secondAttribute="bottom" constant="32.5" id="EIQ-h9-xjC"/>
+                            <constraint firstItem="XDK-En-yrH" firstAttribute="leading" secondItem="5fo-ec-5oo" secondAttribute="trailing" constant="8" symbolic="YES" id="Frh-MC-h3P"/>
+                            <constraint firstItem="9Xq-Fd-86g" firstAttribute="centerY" secondItem="MaN-Wv-xsn" secondAttribute="centerY" id="GQe-Jy-QDO"/>
                             <constraint firstItem="EKL-Ff-i5b" firstAttribute="leading" secondItem="XDK-En-yrH" secondAttribute="leading" id="HRW-JY-zYI"/>
+                            <constraint firstItem="MaN-Wv-xsn" firstAttribute="leading" secondItem="Tvb-2K-ZWp" secondAttribute="leading" constant="20" id="J79-wo-hA4"/>
                             <constraint firstItem="XDK-En-yrH" firstAttribute="trailing" secondItem="EKL-Ff-i5b" secondAttribute="trailing" id="Lv8-e3-b1A"/>
-                            <constraint firstItem="EKL-Ff-i5b" firstAttribute="bottom" secondItem="5fo-ec-5oo" secondAttribute="bottom" id="X8x-0q-jvH"/>
-                            <constraint firstItem="FJq-Rm-ds6" firstAttribute="top" secondItem="9Xq-Fd-86g" secondAttribute="bottom" constant="8" symbolic="YES" id="Xv1-Ib-1kd"/>
-                            <constraint firstItem="9Xq-Fd-86g" firstAttribute="leading" secondItem="1qM-Bh-emI" secondAttribute="leadingMargin" id="Yu1-0q-mV2"/>
-                            <constraint firstItem="XDK-En-yrH" firstAttribute="top" secondItem="fIm-Ob-hFa" secondAttribute="bottom" id="ZVO-XW-pCF"/>
+                            <constraint firstItem="FJq-Rm-ds6" firstAttribute="top" secondItem="MaN-Wv-xsn" secondAttribute="bottom" constant="1.5" id="QuM-gq-aFj"/>
                             <constraint firstItem="FJq-Rm-ds6" firstAttribute="leading" secondItem="Tvb-2K-ZWp" secondAttribute="leading" id="adc-Rw-u7P"/>
                             <constraint firstItem="5fo-ec-5oo" firstAttribute="leading" secondItem="Tvb-2K-ZWp" secondAttribute="leading" constant="20" id="doX-Jp-t3k"/>
                             <constraint firstAttribute="trailingMargin" secondItem="EKL-Ff-i5b" secondAttribute="trailing" id="eZn-wj-V1A"/>
                             <constraint firstItem="5fo-ec-5oo" firstAttribute="top" secondItem="Tvb-2K-ZWp" secondAttribute="top" id="elT-kk-tLU"/>
-                            <constraint firstItem="EKL-Ff-i5b" firstAttribute="top" secondItem="XDK-En-yrH" secondAttribute="bottom" id="gKQ-cR-rph"/>
                             <constraint firstItem="FJq-Rm-ds6" firstAttribute="trailing" secondItem="Tvb-2K-ZWp" secondAttribute="trailing" id="huI-Cw-1cV"/>
                             <constraint firstItem="EKL-Ff-i5b" firstAttribute="leading" secondItem="5fo-ec-5oo" secondAttribute="trailing" constant="8" symbolic="YES" id="iqF-fD-2Id"/>
+                            <constraint firstItem="XDK-En-yrH" firstAttribute="top" secondItem="fIm-Ob-hFa" secondAttribute="bottom" id="jfl-Aj-U5v"/>
                             <constraint firstAttribute="bottom" secondItem="FJq-Rm-ds6" secondAttribute="bottom" id="n0P-GA-bHW"/>
-                            <constraint firstItem="9Xq-Fd-86g" firstAttribute="top" secondItem="5fo-ec-5oo" secondAttribute="bottom" constant="8" symbolic="YES" id="q4B-ua-oEv"/>
+                            <constraint firstItem="9Xq-Fd-86g" firstAttribute="leading" secondItem="MaN-Wv-xsn" secondAttribute="trailing" constant="8" symbolic="YES" id="uoD-QB-wtR"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Profile" id="wxl-C5-1bG">
@@ -255,6 +266,7 @@
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="qjP-D1-VGw">
                                 <rect key="frame" x="20" y="5" width="92" height="34.5"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" name="CTBlue"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Logout"/>
                                 <connections>
@@ -284,8 +296,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active Games:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gZc-gW-J1M">
-                                <rect key="frame" x="20" y="88" width="201" height="36"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active Games" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gZc-gW-J1M">
+                                <rect key="frame" x="73" y="88" width="194" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -316,10 +328,10 @@
                                                         <constraint firstAttribute="height" constant="64" id="yAX-HJ-b3z"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Board is 00% filled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kJb-Zx-Rb9">
-                                                    <rect key="frame" x="92" y="59" width="121.5" height="17"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="game started at 00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kJb-Zx-Rb9">
+                                                    <rect key="frame" x="92" y="59" width="144.5" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <color key="textColor" name="CTBlue"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -343,8 +355,8 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Pending Invites:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oft-ag-U2A">
-                                <rect key="frame" x="20" y="410" width="223" height="36"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Pending Invites" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oft-ag-U2A">
+                                <rect key="frame" x="73" y="410" width="215" height="36"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <nil key="textColor"/>
@@ -368,7 +380,7 @@
                                                         <constraint firstAttribute="height" constant="24" id="jqJ-Xo-bhU"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" name="CTBlue"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t5W-gY-waA">
@@ -412,14 +424,24 @@
                                     <segue destination="K39-7d-p0e" kind="presentation" identifier="newGame" modalPresentationStyle="fullScreen" id="Hod-gC-dd1"/>
                                 </connections>
                             </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="envelope" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bmZ-yz-YqY">
+                                <rect key="frame" x="20" y="412" width="45" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="square.grid.3x2" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BYA-bd-1dA">
+                                <rect key="frame" x="20" y="92" width="45" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Xsf-DX-OVI"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="gZc-gW-J1M" firstAttribute="top" secondItem="Xsf-DX-OVI" secondAttribute="top" id="0J4-NV-JCv"/>
                             <constraint firstItem="2zw-iV-LLa" firstAttribute="centerX" secondItem="Xsf-DX-OVI" secondAttribute="centerX" id="9qy-qG-37W"/>
-                            <constraint firstItem="gZc-gW-J1M" firstAttribute="leading" secondItem="qCO-lp-oJX" secondAttribute="leadingMargin" id="F93-iM-jDG"/>
                             <constraint firstItem="Xsf-DX-OVI" firstAttribute="trailing" secondItem="2zw-iV-LLa" secondAttribute="trailing" constant="20" id="JCs-Yi-LFj"/>
+                            <constraint firstItem="gZc-gW-J1M" firstAttribute="leading" secondItem="Xsf-DX-OVI" secondAttribute="leading" constant="73" id="K2H-fR-ayA"/>
                             <constraint firstItem="Xsf-DX-OVI" firstAttribute="bottom" secondItem="2zw-iV-LLa" secondAttribute="bottom" constant="1" id="Lpw-Io-Guo"/>
                             <constraint firstItem="2zw-iV-LLa" firstAttribute="leading" secondItem="Xsf-DX-OVI" secondAttribute="leading" constant="20" id="vPD-GU-MQb"/>
                         </constraints>
@@ -654,7 +676,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="tintColor" name="CTBlue"/>
-                        <color key="selectedImageTintColor" name="CTBlue"/>
+                        <color key="selectedImageTintColor" name="CTOrange"/>
                     </tabBar>
                     <connections>
                         <segue destination="9xO-Ph-p3q" kind="relationship" relationship="viewControllers" id="Iwz-Ti-sR3"/>
@@ -675,6 +697,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="hpj-gI-HeU">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" name="CTOrange"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -694,6 +719,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="E1I-RO-wWU">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" name="CTOrange"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -714,6 +742,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="hx8-VT-oua">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" name="CTOrange"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -768,6 +799,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="XMH-vm-lOr">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" name="CTOrange"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -786,6 +820,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="QZB-Wd-A8p">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" name="CTOrange"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
@@ -800,12 +837,15 @@
     <resources>
         <image name="LaunchLogo" width="90" height="90"/>
         <image name="checkmark" catalog="system" width="128" height="114"/>
+        <image name="envelope" catalog="system" width="128" height="93"/>
         <image name="gamecontroller" catalog="system" width="128" height="80"/>
         <image name="gearshape" catalog="system" width="128" height="121"/>
+        <image name="person.2.fill" catalog="system" width="128" height="80"/>
         <image name="person.circle" catalog="system" width="128" height="121"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
         <image name="plus" catalog="system" width="128" height="113"/>
         <image name="square.and.pencil" catalog="system" width="128" height="115"/>
+        <image name="square.grid.3x2" catalog="system" width="128" height="80"/>
         <image name="star.fill" catalog="system" width="128" height="116"/>
         <namedColor name="CTBlue">
             <color red="0.25499999523162842" green="0.42599999904632568" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -818,9 +858,6 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/meta_capstone/LeaderboardCell.h
+++ b/meta_capstone/LeaderboardCell.h
@@ -7,10 +7,11 @@
 
 #import <UIKit/UIKit.h>
 #import "Parse/Parse.h"
+#import "TableViewCell+ProfileMethods.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface LeaderboardCell : UITableViewCell
+@interface LeaderboardCell : TableViewCell_ProfileMethods
 @property (strong, nonatomic) IBOutlet UILabel *rankLabel;
 @property (strong, nonatomic) IBOutlet UIImageView *userImage;
 @property (strong, nonatomic) IBOutlet UILabel *userNameLabel;

--- a/meta_capstone/LeaderboardCell.m
+++ b/meta_capstone/LeaderboardCell.m
@@ -18,7 +18,6 @@
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
-
     // Configure the view for the selected state
 }
 
@@ -35,6 +34,10 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
         self.userImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+        self.userImage.layer.cornerRadius = self.userImage.frame.size.width / 2;
+        if (error != nil) {
+            self.userImage.image = [UIImage systemImageNamed:@"person.circle"];
+        }
     }];
 }
 

--- a/meta_capstone/LeaderboardCell.m
+++ b/meta_capstone/LeaderboardCell.m
@@ -26,10 +26,7 @@
     self.userTimeLabel.text = [NSString stringWithFormat:@"Avg time: %@s", user[@"avgTime"]];
     self.rankLabel.text = [NSString stringWithFormat:@"#%ld", (long) rank];
     
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
-    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
-    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
-    self.userImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.userImage.image = [self getProfilePictureForUser:user[@"fbID"]];
     self.userImage.layer.cornerRadius = self.userImage.frame.size.width / 2;
 }
 

--- a/meta_capstone/LeaderboardCell.m
+++ b/meta_capstone/LeaderboardCell.m
@@ -26,19 +26,11 @@
     self.userTimeLabel.text = [NSString stringWithFormat:@"Avg time: %@s", user[@"avgTime"]];
     self.rankLabel.text = [NSString stringWithFormat:@"#%ld", (long) rank];
     
-    //get profile picture
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-    initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", user[@"fbID"]]
-        parameters:nil
-        HTTPMethod:@"GET"];
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
-        self.userImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
-        self.userImage.layer.cornerRadius = self.userImage.frame.size.width / 2;
-        if (error != nil) {
-            self.userImage.image = [UIImage systemImageNamed:@"person.circle"];
-        }
-    }];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
+    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+    self.userImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.userImage.layer.cornerRadius = self.userImage.frame.size.width / 2;
 }
 
 @end

--- a/meta_capstone/SearchUserCell.h
+++ b/meta_capstone/SearchUserCell.h
@@ -7,10 +7,11 @@
 
 #import <UIKit/UIKit.h>
 #import "Parse/Parse.h"
+#import "TableViewCell+ProfileMethods.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SearchUserCell : UITableViewCell
+@interface SearchUserCell : TableViewCell_ProfileMethods
 
 @property (strong, nonatomic) IBOutlet UIImageView *profileImage;
 @property (strong, nonatomic) IBOutlet UILabel *profileUserLabel;

--- a/meta_capstone/SearchUserCell.m
+++ b/meta_capstone/SearchUserCell.m
@@ -54,6 +54,7 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
         self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
     }];
 
 }

--- a/meta_capstone/SearchUserCell.m
+++ b/meta_capstone/SearchUserCell.m
@@ -46,17 +46,11 @@
     
     self.profileUserLabel.text = user[@"name"];
     
-    //get profile picture
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-    initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", user[@"fbID"]]
-        parameters:nil
-        HTTPMethod:@"GET"];
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
-        self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
-        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
-    }];
-
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
+    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+    self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
 }
 
 - (IBAction)didTapAdd:(id)sender {

--- a/meta_capstone/SearchUserCell.m
+++ b/meta_capstone/SearchUserCell.m
@@ -45,11 +45,7 @@
         [self.inviteButton setImage:[UIImage systemImageNamed:@"plus"] forState:UIControlStateNormal];
     
     self.profileUserLabel.text = user[@"name"];
-    
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
-    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
-    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
-    self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.profileImage.image = [self getProfilePictureForUser:user[@"fbID"]];
     self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
 }
 

--- a/meta_capstone/SimpleProfileCell.h
+++ b/meta_capstone/SimpleProfileCell.h
@@ -7,10 +7,11 @@
 
 #import <UIKit/UIKit.h>
 #import "Parse/Parse.h"
+#import "TableViewCell+ProfileMethods.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SimpleProfileCell : UITableViewCell
+@interface SimpleProfileCell : TableViewCell_ProfileMethods
 
 @property (strong, nonatomic) IBOutlet UIImageView *profileImage;
 @property (strong, nonatomic) IBOutlet UILabel *profileUserLabel;

--- a/meta_capstone/SimpleProfileCell.m
+++ b/meta_capstone/SimpleProfileCell.m
@@ -32,6 +32,7 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
         self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
     }];
 }
 

--- a/meta_capstone/SimpleProfileCell.m
+++ b/meta_capstone/SimpleProfileCell.m
@@ -23,11 +23,7 @@
 
 - (void)setCellInfo:(PFObject *)user {
     self.profileUserLabel.text = user[@"name"];
-    
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
-    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
-    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
-    self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.profileImage.image = [self getProfilePictureForUser:user[@"fbID"]];
     self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
 }
 

--- a/meta_capstone/SimpleProfileCell.m
+++ b/meta_capstone/SimpleProfileCell.m
@@ -24,16 +24,11 @@
 - (void)setCellInfo:(PFObject *)user {
     self.profileUserLabel.text = user[@"name"];
     
-    //get profile picture
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-    initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", user[@"fbID"]]
-        parameters:nil
-        HTTPMethod:@"GET"];
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
-        self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
-        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
-    }];
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", user[@"fbID"]]];
+    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+    self.profileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+    self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
 }
 
 @end

--- a/meta_capstone/TableViewCell+ProfileMethods.h
+++ b/meta_capstone/TableViewCell+ProfileMethods.h
@@ -1,0 +1,19 @@
+//
+//  TableViewCell+ProfileMethods.h
+//  meta_capstone
+//
+//  Created by Nikita Singh on 8/11/22.
+//
+
+#import <UIKit/UIKit.h>
+#import "Parse/Parse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TableViewCell_ProfileMethods : UITableViewCell
+
+- (UIImage *) getProfilePictureForUser : (NSString *) userID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/meta_capstone/TableViewCell+ProfileMethods.m
+++ b/meta_capstone/TableViewCell+ProfileMethods.m
@@ -1,0 +1,30 @@
+//
+//  TableViewCell+ProfileMethods.m
+//  meta_capstone
+//
+//  Created by Nikita Singh on 8/11/22.
+//
+
+#import "TableViewCell+ProfileMethods.h"
+
+@implementation TableViewCell_ProfileMethods
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+- (UIImage *) getProfilePictureForUser : (NSString *) userID {
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", userID]];
+    NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+    NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+    return [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+}
+
+@end

--- a/meta_capstone/ViewControllers/LeaderboardViewController.m
+++ b/meta_capstone/ViewControllers/LeaderboardViewController.m
@@ -19,7 +19,6 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [self getLeaderboard];
-    [self.tableView reloadData];
 }
 
 - (void)viewDidLoad {
@@ -37,6 +36,7 @@
     
     NSArray *users = [query findObjects];
     self.usersArray = [NSMutableArray arrayWithArray:users];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
 }
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {

--- a/meta_capstone/ViewControllers/SelfProfileViewController.m
+++ b/meta_capstone/ViewControllers/SelfProfileViewController.m
@@ -32,7 +32,6 @@
     
     self.tableView.dataSource = self;
     [self setProfileData];
-    
 }
 
 - (void)setProfileData {
@@ -60,11 +59,9 @@
         NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
         self.selfProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
         self.selfProfileImage.layer.cornerRadius = self.selfProfileImage.frame.size.width / 2;
-        
     }
     
     [self getRecentlyPlayedWith: recentsIDs];
-
 }
 
 - (void)getRecentlyPlayedWith : (NSMutableArray *)recentsIDs {
@@ -73,6 +70,7 @@
 
     NSArray *users = [query findObjects];
     self.recentsArray = [NSMutableArray arrayWithArray:users];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
 }
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {

--- a/meta_capstone/ViewControllers/SelfProfileViewController.m
+++ b/meta_capstone/ViewControllers/SelfProfileViewController.m
@@ -55,16 +55,11 @@
         self.bestTimeLabel.text = [NSString stringWithFormat:@"Best Time: %@s", userObjects.firstObject[@"bestTime"]];
         self.avgTimeLabel.text = [NSString stringWithFormat:@"Average Time: %@s", userObjects.firstObject[@"avgTime"]];
         
-        //get profile picture
-        FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-        initWithGraphPath:[NSString stringWithFormat:@"/%@?fields=picture.type(large)", self.currUserID]
-            parameters:nil
-            HTTPMethod:@"GET"];
-        [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-            NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
-            self.selfProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
-            self.selfProfileImage.layer.cornerRadius = self.selfProfileImage.frame.size.width / 2;
-        }];
+        NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://graph.facebook.com/%@/picture?redirect=false&type=large", self.currUserID]];
+        NSDictionary *s = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:url] options:0 error:nil];
+        NSURL *picUrl = [NSURL URLWithString:[[s objectForKey:@"data"] objectForKey:@"url"]];
+        self.selfProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:picUrl]];
+        self.selfProfileImage.layer.cornerRadius = self.selfProfileImage.frame.size.width / 2;
         
     }
     

--- a/meta_capstone/ViewControllers/SelfProfileViewController.m
+++ b/meta_capstone/ViewControllers/SelfProfileViewController.m
@@ -63,6 +63,7 @@
         [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
             NSURL *url = [NSURL URLWithString:[[[(NSDictionary*) result objectForKey:@"picture"] objectForKey:@"data"] objectForKey:@"url"]];
             self.selfProfileImage.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+            self.selfProfileImage.layer.cornerRadius = self.selfProfileImage.frame.size.width / 2;
         }];
         
     }


### PR DESCRIPTION
## Description
- fixed bug where completion alert shows continuously for host after game is finished. timers were not being invalidated properly, so updated that.
- added a catch for profile pictures to show a substitute icon if a profile picture is unable to load. Found a new way to fetch profile pictures so they consistently show up for all users, so replaced this with new fetch code.
- rounded new game and start game buttons
- added icons to active games, pending invites, and recently played with tableviews
- removed settings tab
- adjusted colors and spacing of labels
- added fading reload to all tableviews
- reduced duplicate code by adding profile picture fetch to a cell interface and utilizing it where needed

## Milestones
Cleaning up UI and fixing visual bugs

## Test Plan
<img width="485" alt="Screen Shot 2022-08-12 at 11 55 23 AM" src="https://user-images.githubusercontent.com/22784306/184425197-05692d65-c134-415a-9924-329fc01486d6.png">
<img width="485" alt="Screen Shot 2022-08-12 at 11 55 35 AM" src="https://user-images.githubusercontent.com/22784306/184425207-43f99791-1e46-44f6-a104-783fcb8134f9.png">
<img width="485" alt="Screen Shot 2022-08-12 at 11 55 42 AM" src="https://user-images.githubusercontent.com/22784306/184425216-00320011-45ee-48bb-a902-cae791574052.png">

